### PR TITLE
feat: add `configure` command for managing default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ cligen new
 ```
 
 Follow the prompts to generate the app, and then open the generated README file for instructions on what to do next.
+
+# Docs
+
+## Config
+
+Cligen supports a yaml configuration file to preset values for generated applications. It's stored 
+in your home directory (`~/.config/.cligen.yaml`)
+
+Use the `configure` command to set up and save the configuration file to the correct location.
+
+```yaml
+homebrew:
+    enabled: true
+    repo: <insert repo name>
+    github_username: <insert repo owner's github username, e.g. twinsnes>
+```
+

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/twinsnes/cligen/internal/config"
+
+	"github.com/manifoldco/promptui"
+	"github.com/urfave/cli/v3"
+)
+
+func configureCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "configure",
+		Usage: "Configure default options for new CLI apps.",
+		Flags: []cli.Flag{},
+		Commands: []*cli.Command{
+			configureFileLocationCmd(),
+		},
+		Action: func(c context.Context, cmd *cli.Command) error {
+			return configurePrompt()
+		},
+	}
+}
+
+func configureFileLocationCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "location",
+		Usage: "Display the location of the configuration file.",
+		Action: func(c context.Context, cmd *cli.Command) error {
+			path, err := config.GetConfigPath()
+			if err != nil {
+				return err
+			}
+			fmt.Println(path)
+			return nil
+		},
+	}
+}
+
+func configurePrompt() error {
+
+	conf, err := config.LoadConfig()
+
+	if err != nil {
+		return err
+	}
+
+	enabled, err := promptForHomebrewEnabled()
+
+	if err != nil {
+		return err
+	}
+
+	conf.HomebrewConfig.Enabled = enabled
+
+	username, err := promtForGithubUsername(conf.HomebrewConfig.GithubUsername)
+	if err != nil {
+		return err
+	}
+	conf.HomebrewConfig.GithubUsername = username
+
+	repo, err := promptForHomebrewRepo(conf.HomebrewConfig.Repo)
+	if err != nil {
+		return err
+	}
+	conf.HomebrewConfig.Repo = repo
+
+	err = conf.SaveConfig()
+	if err != nil {
+		return err
+	}
+
+	path, _ := config.GetConfigPath()
+
+	fmt.Println("Configuration saved to: ", path)
+	return nil
+}
+
+func promptForHomebrewEnabled() (bool, error) {
+	prompt := promptui.Prompt{
+		Label:     "Enable Homebrew tap?",
+		IsConfirm: true,
+	}
+
+	_, err := prompt.Run()
+	if err != nil {
+		if errors.Is(err, promptui.ErrAbort) {
+			return false, nil
+		}
+		fmt.Println("Prompt failed:", err)
+		return false, err
+	}
+
+	return true, nil
+}
+
+func promtForGithubUsername(def string) (string, error) {
+	prompt := promptui.Prompt{
+		Label:   "Homebrew Github username",
+		Default: def,
+	}
+
+	return prompt.Run()
+}
+
+func promptForHomebrewRepo(def string) (string, error) {
+	prompt := promptui.Prompt{
+		Label:   "Homebrew repo name",
+		Default: def,
+	}
+
+	return prompt.Run()
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,12 +9,14 @@ import (
 )
 
 func Run() {
+
 	app := &cli.Command{
 		Name:    "cligen",
 		Usage:   "Generate a new Go CLI app scaffold powered by urfave/cli",
 		Version: "0.1.0",
 		Commands: []*cli.Command{
 			newCmd(),
+			configureCmd(),
 		},
 	}
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"github.com/twinsnes/cligen/internal/config"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,7 +21,14 @@ func newCmd() *cli.Command {
 		Usage: "Create a new CLI app in the current directory",
 		Flags: []cli.Flag{},
 		Action: func(c context.Context, cmd *cli.Command) error {
-			templateOptions, err := promptForOptions()
+
+			conf, err := config.LoadConfig()
+
+			if err != nil {
+				return err
+			}
+
+			templateOptions, err := promptForOptions(conf)
 
 			if err != nil {
 				return err
@@ -35,9 +43,13 @@ func newCmd() *cli.Command {
 	}
 }
 
-func promptForOptions() (gen.TemplateOptions, error) {
+func promptForOptions(conf *config.Config) (gen.TemplateOptions, error) {
+
 	templateOptions := gen.TemplateOptions{
 		OutputPathPrefix: ".",
+		HomebrewEnabled:  conf.HomebrewConfig.Enabled,
+		HomebrewRepo:     conf.HomebrewConfig.Repo,
+		HomebrewUsername: conf.HomebrewConfig.GithubUsername,
 	}
 
 	result, err := promptForGolangVersion()

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/urfave/cli/v3 v3.4.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,5 +16,7 @@ github.com/urfave/cli/v3 v3.4.1 h1:1M9UOCy5bLmGnuu1yn3t3CB4rG79Rtoxuv1sPhnm6qM=
 github.com/urfave/cli/v3 v3.4.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the configuration of cligen.
+type Config struct {
+	HomebrewConfig HomebrewConfig `yaml:"homebrew"`
+}
+
+// HomebrewConfig represents the configuration of the Homebrew tap.
+type HomebrewConfig struct {
+	Enabled        bool   `yaml:"enabled"`
+	Repo           string `yaml:"repo"`
+	GithubUsername string `yaml:"github_username"`
+}
+
+const (
+	Filename = ".cligen.yaml"
+	Dir      = "~/.config"
+)
+
+// NewConfig creates a new Config instance with default values
+func NewConfig() *Config {
+	return &Config{
+		HomebrewConfig: HomebrewConfig{
+			Enabled:        true,
+			Repo:           "<insert repo name>",
+			GithubUsername: "<insert repo owner's github username, e.g. twinsnes>",
+		},
+	}
+}
+
+// LoadConfig loads the config file from the default location and returns a Config instance.
+// If the config file doesn't exist, it returns a Config instance with default values.
+// If the config file exists but cannot be read, it returns an error.
+// If the config file exists but cannot be parsed, it returns an error.
+func LoadConfig() (*Config, error) {
+
+	fullPath, err := GetConfigPath()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config path: %w", err)
+	}
+
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		return NewConfig(), nil
+	}
+
+	// Read the config file
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", fullPath, err)
+	}
+
+	// Parse YAML content
+	config := NewConfig()
+	if err := yaml.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file %s: %w", fullPath, err)
+	}
+
+	return config, nil
+}
+
+func (c *Config) SaveConfig() error {
+
+	fullPath, err := GetConfigPath()
+	if err != nil {
+		return fmt.Errorf("failed to get config path: %w", err)
+	}
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	err = os.WriteFile(fullPath, data, 0644)
+
+	return err
+}
+
+func GetConfigPath() (string, error) {
+	configDir := Dir
+
+	// Expand the home directory if the path starts with ~
+	if strings.HasPrefix(configDir, "~") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		configDir = strings.Replace(configDir, "~", homeDir, 1)
+	}
+
+	return filepath.Join(configDir, Filename), nil
+}

--- a/internal/gen/main.go
+++ b/internal/gen/main.go
@@ -16,6 +16,9 @@ type TemplateOptions struct {
 	OutputPathPrefix string
 	AppName          string
 	ModuleName       string
+	HomebrewRepo     string
+	HomebrewEnabled  bool
+	HomebrewUsername string
 }
 
 type templatePath struct {

--- a/internal/git/main.go
+++ b/internal/git/main.go
@@ -70,10 +70,8 @@ func NormalizeRemoteToModule(remote string) string {
 	if s == "" {
 		return ""
 	}
-	// Trim trailing .git if present
-	if strings.HasSuffix(s, ".git") {
-		s = strings.TrimSuffix(s, ".git")
-	}
+
+	s = strings.TrimSuffix(s, ".git")
 
 	var host, path string
 

--- a/templates/common/.goreleaser.yaml.tmpl
+++ b/templates/common/.goreleaser.yaml.tmpl
@@ -55,12 +55,13 @@ sboms:
   - id: {{.AppName}}
     disable: false
 
+{{- if .HomebrewEnabled }}
 homebrew_casks:
-  - description: "CLI for generating Go CLI apps with sane defaults and opinionated release pipelines."
-    homepage: "https://github.com/twinsnes/cligen"
+  - description: "Write a small description of the cli purpose"
+    homepage: "Add link to CLI homepage, or github repo"
     repository:
-      owner: twinsnes
-      name: homebrew-tap
+      owner: {{ .HomebrewUsername }}
+      name: {{ .HomebrewRepo }}
       token: "{{`{{ .Env.TAP_GITHUB_TOKEN }}`}}"
     hooks:
       post:
@@ -69,3 +70,4 @@ homebrew_casks:
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/{{`{{.ProjectName}}`}}"]
           end
+ {{ end }}


### PR DESCRIPTION
- Introduced a new `configure` command to set up and manage defaults for new CLI apps.
- Added support for a YAML configuration file stored in `~/.config/.cligen.yaml`.
- Integrated prompts to configure Homebrew-related settings.
- Updated `new` command to use values from the configuration file.
- Enhanced GoReleaser templates to support conditional Homebrew configuration.